### PR TITLE
Add sliding median filter to uss fsm

### DIFF
--- a/Project2/src/main.c
+++ b/Project2/src/main.c
@@ -144,10 +144,8 @@ uint8_t g_LeftDutyCycle = 0x00;
 uint8_t g_RightDutyCycle = 0x00;
 float g_FrontDist = 0.00f;
 float g_LeftDist = 0.00f;
-float front_buf[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
-float front_buf_sorted[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
-float left_buf[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
-float left_buf_sorted[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
+uint32_t front_buf[5] = {};
+uint32_t left_buf[5] = {};
 
 // Initialize Ultrasonic Sensors
 UltrasonicSensor FrontUSS = {0, 3, 3};
@@ -585,6 +583,48 @@ void read_2_uss_fsm(UltrasonicSensor * uss1, UltrasonicSensor * uss2, float * di
     next_state = send_trig;
   }
   state = next_state;
+}
+
+void SelectionSort(int intArray[], int arrayLength)
+{
+    int smallest;
+
+    // Go through all array elements up to the second to last elemnt. On the last 
+    // iteration, there are only two elements left in the unsorted array to compare
+    for (int currentElement = 0; currentElement < arrayLength - 1; currentElement++)
+    {
+        // For the sub-array of currentElement to the end of the array, find the
+        // position of the smallest element
+
+        // Initialize the smallest element to the first element in the sub array
+        smallest = currentElement;
+
+        // Check ALL other elements in the sub array against the current smallest
+        for (int index = currentElement + 1; index < arrayLength; index++)
+        {
+            // If the current element is smaller than the smallest element, update the smallest
+            if (intArray[index] < intArray[smallest])
+            {
+                // We found a new smallest element
+                smallest = index;
+            }
+        }
+
+        // Now that the sub-array has been searched, we have the index of the smallest
+        // value. Now we can swap the values contained in the current element and the
+        // smallest element
+        Swap(&intArray[currentElement], &intArray[smallest]);
+    }
+}
+
+void Swap(int * pFirst, int * pSecond)
+{
+    // Store first in temp
+	int temp = *pFirst;
+
+    // Swap
+	*pFirst = *pSecond;
+	*pSecond = temp;
 }
 
 void celebration() {

--- a/Project2/src/main.c
+++ b/Project2/src/main.c
@@ -144,6 +144,10 @@ uint8_t g_LeftDutyCycle = 0x00;
 uint8_t g_RightDutyCycle = 0x00;
 float g_FrontDist = 0.00f;
 float g_LeftDist = 0.00f;
+float front_buf[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
+float front_buf_sorted[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
+float left_buf[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
+float left_buf_sorted[5] = [0.00f, 0.00f, 0.00f, 0.00f, 0.00f];
 
 // Initialize Ultrasonic Sensors
 UltrasonicSensor FrontUSS = {0, 3, 3};

--- a/Project2/src/main.c
+++ b/Project2/src/main.c
@@ -50,7 +50,7 @@
 #define CNT_PER_INCH 45
 #define HW_TIME_PER_SEC 565001
 #define US_PER_TICK  1.77f
-#define USS_READ_INTERVAL 0.5f
+#define USS_READ_INTERVAL 0.060f // 60ms delay (4m max range)
 #define MED_FILT_WINDOW 5
 #define BASE_DUTY_CYCLE 0xBF
 #define KP 0.1

--- a/Project2/src/main.c
+++ b/Project2/src/main.c
@@ -542,11 +542,11 @@ void read_2_uss_fsm(UltrasonicSensor * uss1,
       clear_trig_pin(*uss2);
       next_state = count_echo_duration;
 
-    // Ensure flags are cleared
-    echo1_read = false;
-    echo2_read = false;
-    last_echo_1 = false;
-    last_echo_2 = false;
+      // Ensure flags are cleared
+      echo1_read = false;
+      echo2_read = false;
+      last_echo_1 = false;
+      last_echo_2 = false;
     }
     break;
 

--- a/Project2/src/main.c
+++ b/Project2/src/main.c
@@ -518,7 +518,7 @@ void read_2_uss_fsm(UltrasonicSensor * uss1,
                     uint32_t buf1[MED_FILT_WINDOW],
                     uint32_t buf2[MED_FILT_WINDOW]) {
   static uss_state state = send_trig;
-  uss_state next_state = send_trig;
+  uss_state next_state = state;
   static _Bool last_echo_1 = false, last_echo_2 = false;
   static _Bool curr_echo_1 = false, curr_echo_2 = false;
   static _Bool echo1_read = false, echo2_read = false;

--- a/Project2/src/main.c
+++ b/Project2/src/main.c
@@ -144,8 +144,8 @@ uint8_t g_LeftDutyCycle = 0x00;
 uint8_t g_RightDutyCycle = 0x00;
 float g_FrontDist = 0.00f;
 float g_LeftDist = 0.00f;
-uint32_t front_buf[5] = {};
-uint32_t left_buf[5] = {};
+uint32_t front_buf[5] = {0};
+uint32_t left_buf[5] = {0};
 
 // Initialize Ultrasonic Sensors
 UltrasonicSensor FrontUSS = {0, 3, 3};

--- a/Project2/src/main.c
+++ b/Project2/src/main.c
@@ -50,6 +50,7 @@
 #define HW_TIME_PER_SEC 565001
 #define US_PER_TICK  1.77f
 #define USS_READ_INTERVAL 0.5f
+#define MED_FILT_WINDOW 5
 #define BASE_DUTY_CYCLE 0xBF
 #define KP 0.1
 #define KI 0.05
@@ -137,15 +138,20 @@ void read_2_uss_fsm(UltrasonicSensor * uss1,
                     UltrasonicSensor * uss2, 
                     float * dist_1, 
                     float * dist_2);
+void selection_sort(int intArray[], int arrayLength);
+static inline void swap(int * pFirst, int * pSecond);
 void celebration();
 
-// Global Variables for Duty Cycles and distance
+// Global Variables:
 uint8_t g_LeftDutyCycle = 0x00;
 uint8_t g_RightDutyCycle = 0x00;
 float g_FrontDist = 0.00f;
 float g_LeftDist = 0.00f;
-uint32_t front_buf[5] = {0};
-uint32_t left_buf[5] = {0};
+
+// Median Filtering
+static uint32_t front_buf[MED_FILT_WINDOW] = {0};
+static uint32_t left_buf[MED_FILT_WINDOW] = {0};
+uint8_t buf_write_index = 0; // Used for both front and left, updated simultaneously
 
 // Initialize Ultrasonic Sensors
 UltrasonicSensor FrontUSS = {0, 3, 3};
@@ -585,7 +591,7 @@ void read_2_uss_fsm(UltrasonicSensor * uss1, UltrasonicSensor * uss2, float * di
   state = next_state;
 }
 
-void SelectionSort(int intArray[], int arrayLength)
+void selection_sort(int intArray[], int arrayLength)
 {
     int smallest;
 
@@ -617,7 +623,7 @@ void SelectionSort(int intArray[], int arrayLength)
     }
 }
 
-void Swap(int * pFirst, int * pSecond)
+static inline void swap(int * pFirst, int * pSecond)
 {
     // Store first in temp
 	int temp = *pFirst;


### PR DESCRIPTION
Use a sliding median filter of the last five utlrasonic values to reduce noise. Taking the median of the last five values ensures that we don't respond to outliers and lost echoes. This will helo ensure the bot doesn't turn randomly because of a single lost echo.